### PR TITLE
Bugfix in FusionSolar kiosk quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Take the following steps to achieve this:
 # Changelog
 | Version | Description |
 | --- | --- |
+| 2.0.4 | Bugfix for fusionsolar cumulative energy quirk where cumulative energy provided by dashboard shortly decreases with the days production |
 | 2.0.3 | Bugfix in scheduler |
 | 2.0.2 | Default to kW in home assistant with 3 digit precision suggestion |
 | 2.0.1 | Now sending MQTT device discovery message |

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ streamHandler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 streamHandler.setFormatter(formatter)
 logger.addHandler(streamHandler)
-logger.info("PyFusionSolarDataRelay 2.0.3 started")
+logger.info("PyFusionSolarDataRelay 2.0.4 started")
 
 # Config
 conf = Conf(logger).read_and_validate_config()

--- a/modules/fetch_fusionsolar_kiosk.py
+++ b/modules/fetch_fusionsolar_kiosk.py
@@ -23,7 +23,7 @@ class FetchFusionSolarKiosk:
             )
             response.raise_for_status()
         except Exception as e:
-            raise Exception("Error in FetchFusionSolarKiosk API HTTP request. Error info: {e}")
+            raise Exception(f"Error in FetchFusionSolarKiosk API HTTP request. Error info: {e}")
 
         # Attempt to parse the top-level JSON.
         try:

--- a/modules/fetch_fusionsolar_kiosk.py
+++ b/modules/fetch_fusionsolar_kiosk.py
@@ -9,6 +9,7 @@ class FetchFusionSolarKiosk:
     def __init__(self, conf: PyFusionSolarSettings, logger):
         self.conf = conf
         self.logger = logger
+        self.last_lifetime_energy_wh = 0
         self.logger.debug("FetchFusionSolarKiosk class instantiated")
 
     def fetch_fusionsolar_status(self, kiosk_settings: FusionSolarKioskSettings) -> FusionSolarInverterMeasurement:
@@ -57,6 +58,12 @@ class FetchFusionSolarKiosk:
             raise Exception(f"Failed to convert FusionSolarOpenAPI data values to float, out of bounds? {val_err}")
         except TypeError as typ_err:
             raise Exception(f"Failed to convert FusionSolarOpenAPI data values to float, value None? {typ_err}")
+
+        # Set this to fix fusionsolar quirk where cumulativeEnergy will decrease with the days amount of solar production
+        if self.last_lifetime_energy_wh != 0 and lifetime_energy_wh < self.last_lifetime_energy_wh:
+            lifetime_energy_wh = self.last_lifetime_energy_wh
+        else:
+            self.last_lifetime_energy_wh = lifetime_energy_wh
 
         # Extract station information.
         try:


### PR DESCRIPTION
Kiosk data cumulative lifetime counter will show a weird drop after midnight. Fix this in code by not allowing decreasing cumulative lifetime counter.
![image](https://github.com/user-attachments/assets/531d9f7f-bd67-4601-82e8-c39a522111eb)
