### PR TITLE
Add flag pvoutput_skip_zero_power

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 # Project specific ignores
 /config.yaml
 /cache/**/*.json
+
+.idea

--- a/README.md
+++ b/README.md
@@ -195,11 +195,12 @@ All configuration is done through environment variables or an optional `.env` fi
 | influxdb_v2_token | Token for InfluxDBv2, only required if influx2=True | XXXXXXX |
 
 ### PVOutput.org Settings
-| Parameter | Description | Default |
-| --- | --- | --- |
-| pvoutput_module_enabled | Can be `True` or `False`, determines if PVOutput.org API is enabled | False |
-| pvoutput_record_url | API url for PVOutput.org live output posting | [Click url](https://pvoutput.org/service/r2/addstatus.jsp)
-| pvoutput_api_key | API Key for PVOutput.org | yourapikey |
+| Parameter                | Description                                                         | Default                                                    |
+|--------------------------|---------------------------------------------------------------------|------------------------------------------------------------|
+| pvoutput_module_enabled  | Can be `True` or `False`, determines if PVOutput.org API is enabled | False                                                      |
+| pvoutput_record_url      | API url for PVOutput.org live output posting                        | [Click url](https://pvoutput.org/service/r2/addstatus.jsp) |
+| pvoutput_api_key         | API Key for PVOutput.org                                            | yourapikey                                                 |
+| pvoutput_skip_zero_power | Flag to skip events with zero power (i.e. in the night)             | False                                                      |
 
 ### MQTT Settings
 | Parameter | Description | Default |

--- a/modules/conf_models.py
+++ b/modules/conf_models.py
@@ -119,6 +119,7 @@ class PyFusionSolarSettings(BaseSettings):
     pvoutput_module_enabled: bool = Field(default=False)
     pvoutput_record_url: str = Field(default="https://pvoutput.org/service/r2/addstatus.jsp")
     pvoutput_api_key: str = Field(default="yourapikey")
+    pvoutput_skip_zero_power: bool = Field(default=False)
 
     # MQTT
     mqtt_module_enabled: bool = Field(default=False)

--- a/modules/relay_fusionsolar_open_api.py
+++ b/modules/relay_fusionsolar_open_api.py
@@ -79,7 +79,7 @@ class RelayFusionSolarOpenApi:
                     f"Error writing PV data to PVOutput.org for fusionsolar open_api [{inverter_measurement.settings_descriptive_name}] with dev_id [{inverter_measurement.settings_device_id}]: {e}"
                 )
         else:
-            self.logger.debug(f"Skipping publishing to PvOutpu, module disabled, or PVOutput disabled in fusionsolar open_api config.")
+            self.logger.debug(f"Skipping publishing to PvOutput, module disabled, or PVOutput disabled in fusionsolar open_api config.")
 
     def publish_pvdata_to_mqtt(self, inverter_measurement: FusionSolarInverterMeasurement):
         if self.conf.mqtt_module_enabled and ((inverter_measurement.settings is not None and inverter_measurement.settings.output_mqtt) or self.conf.fusionsolar_open_api_mqtt_for_discovered_dev):

--- a/modules/write_pvoutput.py
+++ b/modules/write_pvoutput.py
@@ -14,6 +14,8 @@ class WritePvOutput:
         if self.conf.pvoutput_module_enabled:
             if pvoutput_system_id == 0:
                 self.logger.info(f"Skipping PVOutput API call for (kk)id: {dev_id}, output_pvoutput_system_id is not configured")
+            elif self.conf.pvoutput_skip_zero_power and measurement.real_time_power_w <= 0:
+                self.logger.info(f"Skipping PVOutput API call for (kk)id: {dev_id}, real_time_power_w is {measurement.real_time_power_w}w")
             else:
                 pvoutput_header_obj = {
                     "X-Pvoutput-Apikey": self.conf.pvoutput_api_key,


### PR DESCRIPTION
I want a pretty graph on pvoutput, which starts and ends with actual power generation.
So far, I could configure to run between 5am and 10pm. Anyhow right now in spring, the first power is generated at 7 am.

Thereby added additional flag to skip zero power pushing. If there is zero power generated in timeframe, actually the same values as before are pushed. Those events are not really of interest, thereby I added optional flag `pvoutput_skip_zero_power` which defaults to  False` to keep current behavior by default.