### PR TITLE
Handle no grid meter available

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,37 @@
+name: Latest
+on:
+  push:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  docker_buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU environment
+        uses: docker/setup-qemu-action@v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push all images
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: BUILDX_QEMU_ENV=true
+          tags: odin568/pyfusionsolardatarelay:latest

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 # Project specific ignores
 /config.yaml
 /cache/**/*.json
+
+.idea/

--- a/modules/fetch_fusion_solar_open_api.py
+++ b/modules/fetch_fusion_solar_open_api.py
@@ -143,17 +143,26 @@ class FetchFusionSolarOpenApi:
         Retrieve real-time KPIs from the FusionSolar OpenAPI.
         Uses rate limiting to avoid frequent calls.
 
-        :return: A list of FusionSolarMeterKpi objects containing inverter metrics.
+        :return: A list of FusionSolarMeterKpi objects containing grid meter metrics.
         """
-        self.logger.info(f"Requesting inverter realtimeKpi's from FusionSolarOpenAPI.")
+        self.logger.info(f"Requesting grid meter realtimeKpi's from FusionSolarOpenAPI.")
 
         # Ensure the device list is populated
         if not self.device_list:
             self.update_device_list()
 
+        grid_meters = [
+            str(item["id"])
+            for item in self.device_list
+            if item.get("devTypeId") == 17 and item.get("id") is not None
+        ]
+
+        if not grid_meters:
+            self.logger.warning("No compatible grid meter found. Skipping")
+            return []
+
         url = f"{self.conf.fusionsolar_open_api_url}/thirdData/getDevRealKpi"
-        devices_str = ",".join(str(item["id"]) for item in self.device_list if "id" in item and "devTypeId" in item and item["devTypeId"] == 17)
-        data = {"devTypeId": 17, "devIds": devices_str}
+        data = {"devTypeId": 17, "devIds": ",".join(grid_meters)}
 
         response_json = self._fetch_fusionsolar_data_request(url, data)
         api_measurement_list = response_json.get("data", [])


### PR DESCRIPTION
I only check inverter now via openapi - we don't have a grid meter. Code so far made invalid calls to api as no device of type 17 was found. This is now gracefully handled.